### PR TITLE
Add automatic DB table creation

### DIFF
--- a/src/main/java/com/example/foodapp/dao/RestaurantDao.java
+++ b/src/main/java/com/example/foodapp/dao/RestaurantDao.java
@@ -10,6 +10,30 @@ import java.util.List;
 
 public class RestaurantDao {
 
+    public RestaurantDao() {
+        try {
+            createRestaurantTable();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to ensure restaurants table", e);
+        }
+    }
+
+    public void createRestaurantTable() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS restaurants (" +
+                "id INT AUTO_INCREMENT PRIMARY KEY, " +
+                "name VARCHAR(100) NOT NULL, " +
+                "address VARCHAR(255), " +
+                "phone VARCHAR(20), " +
+                "owner_id INT NOT NULL, " +
+                "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, " +
+                "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" +
+                ")";
+        try (Connection conn = JdbcUtil.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.executeUpdate();
+        }
+    }
+
     /**
      * Inserts a new restaurant row into the DB.
      * On success, sets the generated ID on the Restaurant object.

--- a/src/main/java/com/example/foodapp/dao/UserDao.java
+++ b/src/main/java/com/example/foodapp/dao/UserDao.java
@@ -12,15 +12,12 @@ import java.time.LocalDateTime;
  */
 public class UserDao {
 
-    public UserDao(){
-        Connection conn = null;
-        Statement stmt = null;
-        ResultSet rs = null;
+    public UserDao() {
         try {
-            conn = JdbcUtil.getConnection();
-            System.out.println("Connected to MySQL successfully!");
+            createUserTable();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to ensure users table", e);
         }
-        createUserTable();
     }
 
     public void createUserTable() throws SQLException {


### PR DESCRIPTION
## Summary
- create `restaurants` table if missing on DAO init
- ensure `users` table is created when `UserDao` loads

## Testing
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874881b08848327b67093dcfa04511c